### PR TITLE
Use `jq` and show project icons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ This workflow for Alfred 2 allows you to search issues on an Atlassian Jira inst
 
 ## Dependencies
 
-* `jsawk`
+* [`jq`](https://stedolan.github.io/jq/)
 * `curl`
+* ImageMagick (optional, see settings)
 
 The easiest way to install the dependencies is [`brew`](http://brew.sh/):
 
 ```bash
-$ brew install curl jsawk
+$ brew install curl jq
 ```
 
 ## Installation
-Download the [latest release](https://github.com/swissmanu/search-jira-issues-alfred-workflow/releases/latest) and open the `search.jira-issues.alfredworkflow` file to install it automatically to Alfred.
+Download the [latest release](https://github.com/swissmanu/search-jira-issues-alfred-workflow/releases) and open the `search.jira-issues.alfredworkflow` file to install it automatically to Alfred.
 
 ## Configuration
 You have to create your own `config.json` file before you can use the new workflow:
@@ -38,6 +39,7 @@ You have to create your own `config.json` file before you can use the new workfl
 | `maxResults` | Limit the number of issues to display. | `20` |
 | `emptySearchJql` | This JQL query is executed if you don't enter any search term after the workflows keyword. See [Atlassians JQL documentation](https://confluence.atlassian.com/display/JIRA/Advanced+Searching) for available query options. | `project = 'FOO' ORDER BY lastViewed` |
 | `searchJql` | This JQL query is executed if you enter a search term after the workflows keyword. Use `{query}` to pass the entered search term to JIRA's API. See [Atlassians JQL documentation](https://confluence.atlassian.com/display/JIRA/Advanced+Searching) for available query options. | `project = 'FOO' summary~'{query}' ORDER BY lastViewed` |
+| `convertImages` | Sometimes project icons are SVG images that can not be displayed in Alfred. Set this to true and make sure ImageMagick's `convert` is in your path. | `"convertImages": true` |
 
 ## Usage
 Open your Alfred prompt and start typing `jira`. The workflow will call JIRA's API with the given `emptySearchJql` JQL query if you enter no specific search term.

--- a/buildXMLItems.sh
+++ b/buildXMLItems.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+response=$1
+config=`cat ./config.json | jq -r .`
+user=`jq -r -M .user <<< $config`
+password=`jq -r -M .password <<< $config`
+
+# Cache project icons for items found.
+
+convertImages=`jq -r -M .convertImages <<< $config`
+projectIconData=`echo $response | jq '.issues[]' | jq -r '.fields.project.avatarUrls."48x48" + "|" + .fields.project.key'`
+mkdir -p ./project_icons
+for piData in $projectIconData; do
+  url=$(echo $piData | cut -d"|" -f1)
+  key=$(echo $piData | cut -d"|" -f2)
+  file="./project_icons/$key"
+  if [ ! -f $file ]; then
+    curl -s -u $user:$password $url > $file
+    if [ "$convertImages" = "true" ]; then
+      convert $file "$file.png"
+    fi
+  fi
+done
+
+# Give XML response back.
+
+echo $response | jq '.issues[]' \
+  | jq --argfile config ./config.json '[
+    .key,
+    $config.jiraUrl + "/browse/" + .key,
+    "[" + .key + "]" + " " + .fields.summary,
+    .fields.project.name + " - " + .fields.issuetype.name,
+    .fields.project.key]' \
+  | jq -r -j '
+  "<item uid=\"" + .[0] + "\" valid=\"yes\" arg=\"" + .[1] + "\">" +
+    "<title><![CDATA[" + .[2] + "]]></title>" +
+    "<subtitle><![CDATA[" + .[3] + "]]></subtitle>" +
+    "<icon>project_icons/" + .[4] + ".png</icon>" +
+  "</item>"'

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,9 +1,9 @@
 {
-	"user": "username",
-	"password": "password",
-	"jiraUrl": "https://myjirahost.com",
-
-	"maxResults": 20,
-	"emptySearchJql": "project='XYZ' AND status != closed ORDER BY lastViewed",
-	"searchJql": "project='XYZ' AND (text~'{query}' OR id='{query}') AND status != closed ORDER BY lastViewed"
+  "user": "username",
+  "password": "password",
+  "jiraUrl": "https://myjirahost.com",
+  "maxResults": 20,
+  "emptySearchJql": "project='XYZ' AND status != closed ORDER BY lastViewed",
+  "searchJql": "project='XYZ' AND (text~'{query}' OR id='{query}') AND status != closed ORDER BY lastViewed",
+  "convertImages": false
 }


### PR DESCRIPTION
This pull request is unsolicited and I would completely understand if there were any friction to incorporating it. However, I am willing to update any changes here as you see fit in order to get this merged in. Thanks for your work on this project. Here is what I am submitting:

1. Use the `jq` (https://stedolan.github.io/jq/) bin vs `jsawk`. I had issues with using jsawk since it also relies on spidermonkey. I feel jq is a strong project very easy to use. It also has the benefit of having standalone binary package downloads. 
2. The new `buildXMLItems.sh` is just a refactor to keep `search.js` clean. This file will also iterate over the issues and download each project's icon. Project icons are downloaded once into `./project_icons` using the project key. For example `DES`, etc.
3. As part of the download for each project icon, we optional use ImageMagick to convert the image to a good format, PNG. In my case, some of our project icons were SVGs.

Some things I may need help on or to change:

* I am not super strong in the shell, if you see anything that looks poor or not portable, let me know.
* Should the issue style icons be removed? Should we add more code that allows someone to config on which icon style to show?